### PR TITLE
57 recreate tailwind design system for class reference including color heading and text. Please approve this ticket first as other tickets will be updated accordingly after it is merged

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Dela+Gothic+One:wght@400&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&display=swap');
 @import '../styles/heading.scss';
 @import '../styles/paragraph.scss';
 @import '../styles/color.scss';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,19 +3,32 @@
 @tailwind base;
 @layer base {
   h1 {
-    @apply text-5xl;
+    @apply font-sans_Dela_Gothic_One text-tk56 font-normal leading-[1.2] tracking-[-0.04em];
   }
   h2 {
-    @apply text-4xl;
+    @apply font-sans_Dela_Gothic_One text-tk48 font-normal leading-none tracking-[-0.04em];
   }
   h3 {
-    @apply text-3xl;
+    @apply font-sans_Dela_Gothic_One text-tk32 font-normal leading-none tracking-[-0.04em];
   }
   h4 {
-    @apply text-2xl;
+    @apply font-sans_Dela_Gothic_One text-tk26 font-normal leading-none tracking-[-0.04em];
   }
-  p {
-    @apply text-xl;
+
+  .p1 {
+    @apply font-sans_Montserrat text-tk18 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+  }
+
+  .p2 {
+    @apply font-sans_Montserrat text-tk16 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+  }
+
+  .p3 {
+    @apply font-sans_Montserrat text-tk14 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+  }
+
+  .p4 {
+    @apply font-sans_Montserrat text-tk12 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
   }
 }
 @tailwind components;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Dela+Gothic+One:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&display=swap');
 @tailwind base;
 @layer base {
   h1 {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,32 +3,32 @@
 @tailwind base;
 @layer base {
   h1 {
-    @apply font-sans_Dela_Gothic_One text-tk56 font-normal leading-[1.2] tracking-[-0.04em];
+    @apply font-Dela_Gothic_One text-tk56 font-normal leading-[1.2] tracking-[-0.04em];
   }
   h2 {
-    @apply font-sans_Dela_Gothic_One text-tk48 font-normal leading-none tracking-[-0.04em];
+    @apply font-Dela_Gothic_One text-tk48 font-normal leading-none tracking-[-0.04em];
   }
   h3 {
-    @apply font-sans_Dela_Gothic_One text-tk32 font-normal leading-none tracking-[-0.04em];
+    @apply font-Dela_Gothic_One text-tk32 font-normal leading-none tracking-[-0.04em];
   }
   h4 {
-    @apply font-sans_Dela_Gothic_One text-tk26 font-normal leading-none tracking-[-0.04em];
+    @apply font-Dela_Gothic_One text-tk26 font-normal leading-none tracking-[-0.04em];
   }
 
   .p1 {
-    @apply font-sans_Montserrat text-tk18 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+    @apply font-Montserrat text-tk18 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
   }
 
   .p2 {
-    @apply font-sans_Montserrat text-tk16 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+    @apply font-Montserrat text-tk16 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
   }
 
   .p3 {
-    @apply font-sans_Montserrat text-tk14 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+    @apply font-Montserrat text-tk14 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
   }
 
   .p4 {
-    @apply font-sans_Montserrat text-tk12 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
+    @apply font-Montserrat text-tk12 font-semibold leading-[1.4] tracking-[-0.04em] text-tk_greyDark;
   }
 }
 @tailwind components;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
+@layer base {
+  h1 {
+    @apply text-5xl;
+  }
+  h2 {
+    @apply text-4xl;
+  }
+  h3 {
+    @apply text-3xl;
+  }
+  h4 {
+    @apply text-2xl;
+  }
+  p {
+    @apply text-xl;
+  }
+}
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,110 +9,53 @@ module.exports = {
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    fontSize: {
-      sm: [
-        '0.75rem',
-        {
-          lineHeight: '140%',
-          fontWeight: '600',
-        },
-      ],
-      base: [
-        '0.875rem',
-        {
-          lineHeight: '140%',
-          fontWeight: '600',
-        },
-      ],
-      lg: [
-        '1rem',
-        {
-          lineHeight: '140%',
-          fontWeight: '600',
-        },
-      ],
-      xl: [
-        '1.125rem',
-        {
-          lineHeight: '140%',
-          fontWeight: '600',
-        },
-      ],
-      '2xl': [
-        '1.625rem',
-        {
-          lineHeight: '100%',
-          fontWeight: '400',
-        },
-      ],
-      '3xl': [
-        '2rem',
-        {
-          lineHeight: '100%',
-          fontWeight: '400',
-        },
-      ],
-      '4xl': [
-        '3rem',
-        {
-          lineHeight: '100%',
-          fontWeight: '400',
-        },
-      ],
-      '5xl': [
-        '3.5rem',
-        {
-          lineHeight: '120%',
-          fontWeight: '400',
-        },
-      ],
-    },
-    fontFamily: {
-      sans: ['Dela Gothic One', 'Montserrat'],
+    screens: {
+      sm: '320px',
+      // => @media (min-width: 320px) { ... }
+
+      md: '768px',
+      // => @media (min-width: 768px) { ... }
+
+      lg: '1280px',
+      // => @media (min-width: 1280px) { ... }
+
+      xl: '1920px',
+      // => @media (min-width: 1920px) { ... }
     },
     extend: {
-      screens: {
-        sm: '320px',
-        // => @media (min-width: 320px) { ... }
-
-        md: '768px',
-        // => @media (min-width: 768px) { ... }
-
-        lg: '1280px',
-        // => @media (min-width: 1280px) { ... }
-
-        xl: '1920px',
-        // => @media (min-width: 1920px) { ... }
+      fontFamily: {
+        sans_Dela_Gothic_One: 'Dela Gothic One',
+        sans_Montserrat: 'Montserrat',
+      },
+      fontSize: {
+        tk12: '0.75rem', //12px
+        tk14: '0.875rem', //14px
+        tk16: '1rem', //16px
+        tk18: '1.125rem', //18px
+        tk26: '1.625rem', //26px
+        tk32: '2rem', //32px
+        tk48: '3rem', //48px
+        tk56: '3.5rem', //56px
       },
       colors: {
         /* Primary Color*/
-        cyanDark: '#2b788b',
-        cyanLight: '#c3dce3',
-        pinkDark: '#945069',
-        pinkLight: '#f2d4dc',
-        black: '#000000',
-        greyLight: '#f6f5f4',
-        greyMedium: '#e0e0e0',
-        greyIcon: '#bababa',
-        greyDark: '#757575',
-        Zambezi: '#585858',
+        tk_cyanDark: '#2b788b',
+        tk_cyanLight: '#c3dce3',
+        tk_pinkDark: '#945069',
+        tk_pinkLight: '#f2d4dc',
+        tk_greyLight: '#f6f5f4',
+        tk_greyMedium: '#e0e0e0',
+        tk_greyIcon: '#bababa',
+        tk_greyDark: '#757575',
+        tk_Zambezi: '#585858',
 
         /* Secondary Color*/
-        cyan: '#5996a5',
-        green: {
-          DEFAULT: '#639b6d',
-          LIGHTEN: 'rgba(99, 155, 109, 0.3)',
-        },
-        pink: '#a15993',
-        red: '#a95151',
-        yellow: '#c4a24c',
-        orange: {
-          DEFAULT: '#cb5b43',
-          LIGHTEN: 'rgba(203, 91, 67, 0.3)',
-        },
-
-        /* Generally used color*/
-        $white: '#ffffff',
+        tk_cyan: '#5996a5',
+        tk_green: '#639b6d',
+        tk_pink: '#a15993',
+        tk_red: '#a95151',
+        tk_yellow: '#c4a24c',
+        tk_orange: '#cb5b43',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,8 +24,8 @@ module.exports = {
     },
     extend: {
       fontFamily: {
-        sans_Dela_Gothic_One: 'Dela Gothic One',
-        sans_Montserrat: 'Montserrat',
+        Dela_Gothic_One: 'Dela Gothic One',
+        Montserrat: 'Montserrat',
       },
       fontSize: {
         tk12: '0.75rem', //12px
@@ -47,7 +47,7 @@ module.exports = {
         tk_greyMedium: '#e0e0e0',
         tk_greyIcon: '#bababa',
         tk_greyDark: '#757575',
-        tk_Zambezi: '#585858',
+        tk_zambezi: '#585858',
 
         /* Secondary Color*/
         tk_cyan: '#5996a5',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,67 @@ module.exports = {
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    fontSize: {
+      sm: [
+        '0.75rem',
+        {
+          lineHeight: '140%',
+          fontWeight: '600',
+        },
+      ],
+      base: [
+        '0.875rem',
+        {
+          lineHeight: '140%',
+          fontWeight: '600',
+        },
+      ],
+      lg: [
+        '1rem',
+        {
+          lineHeight: '140%',
+          fontWeight: '600',
+        },
+      ],
+      xl: [
+        '1.125rem',
+        {
+          lineHeight: '140%',
+          fontWeight: '600',
+        },
+      ],
+      '2xl': [
+        '1.625rem',
+        {
+          lineHeight: '100%',
+          fontWeight: '400',
+        },
+      ],
+      '3xl': [
+        '2rem',
+        {
+          lineHeight: '100%',
+          fontWeight: '400',
+        },
+      ],
+      '4xl': [
+        '3rem',
+        {
+          lineHeight: '100%',
+          fontWeight: '400',
+        },
+      ],
+      '5xl': [
+        '3.5rem',
+        {
+          lineHeight: '120%',
+          fontWeight: '400',
+        },
+      ],
+    },
+    fontFamily: {
+      sans: ['Dela Gothic One', 'Montserrat'],
+    },
     extend: {
       screens: {
         sm: '320px',
@@ -17,8 +78,41 @@ module.exports = {
         md: '768px',
         // => @media (min-width: 768px) { ... }
 
-        xl: '1280px',
+        lg: '1280px',
         // => @media (min-width: 1280px) { ... }
+
+        xl: '1920px',
+        // => @media (min-width: 1920px) { ... }
+      },
+      colors: {
+        /* Primary Color*/
+        cyanDark: '#2b788b',
+        cyanLight: '#c3dce3',
+        pinkDark: '#945069',
+        pinkLight: '#f2d4dc',
+        black: '#000000',
+        greyLight: '#f6f5f4',
+        greyMedium: '#e0e0e0',
+        greyIcon: '#bababa',
+        greyDark: '#757575',
+        Zambezi: '#585858',
+
+        /* Secondary Color*/
+        cyan: '#5996a5',
+        green: {
+          DEFAULT: '#639b6d',
+          LIGHTEN: 'rgba(99, 155, 109, 0.3)',
+        },
+        pink: '#a15993',
+        red: '#a95151',
+        yellow: '#c4a24c',
+        orange: {
+          DEFAULT: '#cb5b43',
+          LIGHTEN: 'rgba(203, 91, 67, 0.3)',
+        },
+
+        /* Generally used color*/
+        $white: '#ffffff',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,18 @@ module.exports = {
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        sm: '320px',
+        // => @media (min-width: 320px) { ... }
+
+        md: '768px',
+        // => @media (min-width: 768px) { ... }
+
+        xl: '1280px',
+        // => @media (min-width: 1280px) { ... }
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
created font-family, color and font-size template in tailwind.config.js. 

Style h1,h2,h3,h4, and p tag using existing styles in tailwind.config.js in global.css.

Tested and it is working, so that team can gradually migrate from scss to tailwind ticket by ticket.